### PR TITLE
Update react-native-sesitive-info to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prettier": "^1.4.4",
     "react": "16.0.0-alpha.12",
     "react-native": "^0.45.1",
-    "react-native-sensitive-info": "^5.1.0",
+    "react-native-sensitive-info": "6.0.0-alpha.9",
     "testdouble": "^3.0.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/CodingZeal/redux-persist-sensitive-storage#readme",
   "peerDependencies": {
     "react-native": "*",
-    "react-native-sensitive-info": "3.x - 5.x"
+    "react-native-sensitive-info": "3.x - 6.x"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
I updated the requirements to the new react-native-sensitive-info v6.

All tests still work fine and as expected.